### PR TITLE
Only send RSA key when using encryption

### DIFF
--- a/raop_client.c
+++ b/raop_client.c
@@ -649,23 +649,25 @@ int raopcl_connect(raopcl_t *p, char *host,__u16 destport, int encrypt, int volu
 	//get options
 	if(rtspcl_options(raopcld->rtspcl)) goto erexit;
 	
-	i=rsa_encrypt(raopcld->key,16,rsakey);
-	base64_encode(rsakey,i,&key);
-	remove_char_from_string(key,'=');
-	base64_encode(raopcld->iv,16,&iv);
-	remove_char_from_string(iv,'=');
 	sprintf(sdp,
-            "v=0\r\n"
-            "o=iTunes %s 0 IN IP4 %s\r\n"
-            "s=iTunes\r\n"
-            "c=IN IP4 %s\r\n"
-            "t=0 0\r\n"
-            "m=audio 0 RTP/AVP 96\r\n"
-            "a=rtpmap:96 AppleLossless\r\n"
-            "a=fmtp:96 %d 0 16 40 10 14 2 255 0 0 44100\r\n"
-            "a=rsaaeskey:%s\r\n"
-            "a=aesiv:%s\r\n",
-            sid, rtspcl_local_ip(raopcld->rtspcl), host, MAX_SAMPLES_IN_CHUNK, key, iv);
+		"v=0\r\n"
+		"o=iTunes %s 0 IN IP4 %s\r\n"
+		"s=iTunes\r\n"
+		"c=IN IP4 %s\r\n"
+		"t=0 0\r\n"
+		"m=audio 0 RTP/AVP 96\r\n"
+		"a=rtpmap:96 AppleLossless\r\n"
+		"a=fmtp:96 %d 0 16 40 10 14 2 255 0 0 44100\r\n",
+		sid, rtspcl_local_ip(raopcld->rtspcl), host, MAX_SAMPLES_IN_CHUNK);
+
+	if (raopcld->encrypt) {
+		i=rsa_encrypt(raopcld->key,16,rsakey);
+		base64_encode(rsakey,i,&key);
+		remove_char_from_string(key,'=');
+		base64_encode(raopcld->iv,16,&iv);
+		remove_char_from_string(iv,'=');
+		sprintf(sdp + strlen(sdp), "a=rsaaeskey:%s\r\na=aesiv:%s\r\n", key, iv);
+	}
 
 	remove_char_from_string(sac,'=');
 	if(rtspcl_add_exthds(raopcld->rtspcl, "Apple-Challenge", sac)) goto erexit;


### PR DESCRIPTION
Otherwise the new AirPort Express will respond with `RTSP/1.0 406 Not Acceptable`