### PR TITLE
Allow passing CFLAGS and LDFLAGS to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,16 @@ CC = gcc
 TARGET=raop_play
 DESTDIR =
 
-CFLAGS=-Wall
+override LDFLAGS := $(LDFLAGS)
+override CFLAGS := -Wall $(CFLAGS)
+
 OBJS := raop_play.o raop_client.o rtsp_client.o aexcl_lib.o base64.o aes.o \
-audio_stream.o wav_stream.o 
+audio_stream.o wav_stream.o
 
 all: $(TARGET)
 
 raop_play: $(OBJS)
-	$(CC) -o $@  $^ -lcrypto -lssl -lsamplerate -lid3tag -lpthread
+	$(CC) $(LDFLAGS) -o $@  $^ -lcrypto -lssl -lsamplerate -lid3tag -lpthread
 
 install:
 	cp raop_play /usr/local/bin


### PR DESCRIPTION
This allows building on macOS using something like:

```sh
brew install openssl libsamplerate libid3tag
LDFLAGS=-L/usr/local/opt/openssl/lib CFLAGS=-I/usr/local/opt/openssl/include make
```